### PR TITLE
Update default Solr version to 9.2, update Tika to 2.8.0, add Apache support

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,10 @@
+---
+skip_list:
+  - 'risky-shell-pipe'
+  - 'role-name'
+
+warn_list:
+  - package-latest
+  - unnamed-task
+  - command-instead-of-shell
+  - no-handler

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+---
+repos:
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v6.17.2
+    hooks:
+      - id: ansible-lint

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,14 +1,13 @@
 ---
 solr:
+  domain:
   prefix:
     bin: /var/solr
     var: /var/db/solr
-  version: 7.4.0
-  checksum: sha256:a50eac8dece0acb5e6f0d868c7868ce8174e299752356f3424a15aa39bd64407
+  version: 9.2.0
   tika:
     prefix:
       bin: /var/opt/tika
-    version: "1.20"
-    checksum: sha256:d80ad0f5f3b8d1b58a9ff9c43c6ad7c1c736ef0d9c63ee7e8d83e948aff2d274
+    version: 2.8.0
   synced_config:
   oauth2_proxy:

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -1,24 +1,24 @@
 ---
 - name: Start Solr
-  service:
+  ansible.builtin.service:
     name: solr
     state: started
   register: solr_service_result
 
 - name: Restart Solr
-  service:
+  ansible.builtin.service:
     name: solr
     state: restarted
   when: not (solr_service_result is defined and solr_service_result.changed)
 
 - name: Start Tika
-  service:
+  ansible.builtin.service:
     name: tika
     state: started
   register: tika_service_result
 
 - name: Restart Tika
-  service:
+  ansible.builtin.service:
     name: tika
     state: restarted
   when: not (tika_service_result is defined and tika_service_result.changed)

--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -1,4 +1,9 @@
 ---
 dependencies:
+  - role: dehydrated
   - role: nginx
+    when: inventory_hostname in groups.nginx
+  - role: apache
+    when: inventory_hostname in groups.apache
   - role: oauth2_proxy
+    when: solr.oauth2_proxy is defined and solr.oauth2_proxy

--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -2,7 +2,7 @@
 dependencies:
   - role: dehydrated
   - role: nginx
-    when: inventory_hostname in groups.nginx
+    when: inventory_hostname in groups.nginx or not inventory_hostname in groups.apache
   - role: apache
     when: inventory_hostname in groups.apache
   - role: oauth2_proxy

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include ansible-proserver-solr"
+      ansible.builtin.include_role:
+        name: "ansible-proserver-solr"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,27 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-ubuntu2204-ansible
+    command: /lib/systemd/systemd
+    pre_build_image: true
+    privileged: true
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+verifier:
+  name: ansible
+scenario:
+  name: default
+  test_sequence:
+    - destroy
+    - create
+    - converge
+    - verify

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Example assertion
+      ansible.builtin.assert:
+        that: true

--- a/tasks/apache.yaml
+++ b/tasks/apache.yaml
@@ -1,0 +1,15 @@
+---
+- name: Template Apache configuration
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "{{ render_path }}"
+    owner: "root"
+    group: "{{ root_group }}"
+    mode: "0644"
+  loop_control:
+    label: "{{ render_path }}"
+  vars:
+    render_path: "{{ apache.prefix.config }}/Includes/{{ item | basename | regex_replace('\\.j2$', '') }}"
+  with_fileglob:
+    - "{{ role_path }}/templates/apache/Includes/*.j2"
+  notify: Restart apache

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -7,8 +7,8 @@
 
 - name: Install Nginx template
   ansible.builtin.include_tasks: nginx.yaml
-  when: inventory_hostname in groups.nginx
+  when: (inventory_hostname in groups.nginx) | default(True)
 
 - name: Install Apache template
   ansible.builtin.include_tasks: apache.yaml
-  when: inventory_hostname in groups.apache
+  when: (inventory_hostname in groups.apache) | default(False)

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -7,8 +7,8 @@
 
 - name: Install Nginx template
   ansible.builtin.include_tasks: nginx.yaml
-  when: (inventory_hostname in groups.nginx) | default(True)
+  when: inventory_hostname in groups.nginx or not inventory_hostname in groups.apache
 
 - name: Install Apache template
   ansible.builtin.include_tasks: apache.yaml
-  when: (inventory_hostname in groups.apache) | default(False)
+  when: inventory_hostname in groups.apache

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,4 +1,14 @@
 ---
-- import_tasks: solr.yaml
-- import_tasks: tika.yaml
-- import_tasks: nginx.yaml
+- name: Install Apache Solr
+  ansible.builtin.include_tasks: solr.yaml
+
+- name: Install Apache Tika
+  ansible.builtin.include_tasks: tika.yaml
+
+- name: Install Nginx template
+  ansible.builtin.include_tasks: nginx.yaml
+  when: inventory_hostname in groups.nginx
+
+- name: Install Apache template
+  ansible.builtin.include_tasks: apache.yaml
+  when: inventory_hostname in groups.apache

--- a/tasks/nginx.yaml
+++ b/tasks/nginx.yaml
@@ -1,13 +1,16 @@
 ---
 - name: Template nginx configuration
-  template:
+  ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ render_path }}"
+    owner: "root"
+    group: "{{ root_group }}"
+    mode: "0644"
   loop_control:
     label: "{{ render_path }}"
   vars:
     template_dir: "{{ role_path }}/templates"
-    render_path: "{{ nginx.prefix.config }}/{{ item|strip_prefix(template_dir + '/nginx/')|strip_suffix('.j2') }}"
+    render_path: "{{ nginx.prefix.config }}/http.d/{{ item | basename | regex_replace('\\.j2$', '') }}"
   with_fileglob:
     - "{{ role_path }}/templates/nginx/http.d/*.j2"
   notify: Restart nginx

--- a/tasks/solr.yaml
+++ b/tasks/solr.yaml
@@ -1,54 +1,63 @@
 ---
 - name: Create program directory for Solr
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    owner: root
+    group: "{{ root_group }}"
+    mode: "0755"
   with_items:
     - "{{ solr.prefix.bin }}"
 
 - name: Download Solr
-  get_url:
-    url: "http://archive.apache.org/dist/lucene/solr/{{ solr.version }}/solr-{{ solr.version }}.tgz"
+  ansible.builtin.get_url:
+    url: "https://archive.apache.org/dist/solr/solr/{{ solr.version }}/solr-{{ solr.version }}.tgz"
     dest: "{{ item }}"
-    checksum: "{{ solr.checksum }}"
+    checksum: "sha512:https://archive.apache.org/dist/solr/solr/{{ solr.version }}/solr-{{ solr.version }}.tgz.sha512"
+    owner: root
+    group: "{{ root_group }}"
+    mode: "0644"
   with_items:
     - "{{ solr.prefix.bin }}/solr-{{ solr.version }}.tar.gz"
   register: solr_get_url_result
 
-- block:
-  - name: Stop Solr service
-    service:
-      name: solr
-      state: stopped
-
-  - name: Disable Solr service
-    lineinfile:
-      path: "{{ item }}"
-      regexp: "^solr_enable="
-      line: 'solr_enable="NO"'
-    with_items:
-      - /etc/rc.conf
-
-  - name: Remove old Solr version
-    command: >
-      find {{ item|quote }} -mindepth 1 -not -name solr-{{ solr.version|quote }}.tar.gz -delete
-    with_items:
-      - "{{ solr.prefix.bin }}"
-
-  - name: Unarchive Solr
-    unarchive:
-      src: "{{ solr.prefix.bin }}/solr-{{ solr.version }}.tar.gz"
-      dest: "{{ item }}"
-      extra_opts:
-        - --strip-components=1
-      remote_src: yes
-    with_items:
-      - "{{ solr.prefix.bin }}"
-
+- name: Handle Solr update
   when: solr_get_url_result.changed
+  block:
+    - name: Stop Solr service
+      ansible.builtin.service:
+        name: solr
+        state: stopped
+
+    - name: Disable Solr service
+      ansible.builtin.lineinfile:
+        path: "{{ item }}"
+        regexp: "^solr_enable="
+        line: 'solr_enable="NO"'
+      with_items:
+        - /etc/rc.conf
+
+    - name: Remove old Solr version
+      changed_when: yes
+      ansible.builtin.command:
+        cmd: >-
+          find {{ item | quote }} -mindepth 1 -not -name solr-{{ solr.version | quote }}.tar.gz -delete
+      with_items:
+        - "{{ solr.prefix.bin }}"
+
+    - name: Unarchive Solr
+      ansible.builtin.unarchive:
+        src: "{{ solr.prefix.bin }}/solr-{{ solr.version }}.tar.gz"
+        dest: "{{ item }}"
+        extra_opts:
+          - --strip-components=1
+        remote_src: yes
+      with_items:
+        - "{{ solr.prefix.bin }}"
+
 
 - name: Sync Solr config
-  synchronize:
+  ansible.posix.synchronize:
     src: "{{ solr.synced_config }}/"
     dest: "{{ item }}"
     rsync_opts:
@@ -62,7 +71,7 @@
   notify: Restart Solr
 
 - name: Enable Solr service
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ item }}"
     regexp: "^solr_enable="
     line: 'solr_enable="YES"'

--- a/tasks/tika.yaml
+++ b/tasks/tika.yaml
@@ -1,33 +1,37 @@
 ---
 - name: Create program directory for Tika
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
+    owner: root
+    group: "{{ root_group }}"
+    mode: "0755"
   with_items:
     - "{{ solr.tika.prefix.bin }}"
 
 - name: Download Tika
-  get_url:
-    url: "https://archive.apache.org/dist/tika/tika-server-{{ solr.tika.version }}.jar"
-    dest: "{{ item }}"
-    checksum: "{{ solr.tika.checksum }}"
-  with_items:
-    - "{{ solr.tika.prefix.bin }}/tika-server-{{ solr.tika.version }}.jar"
+  ansible.builtin.get_url:
+    url: "https://archive.apache.org/dist/tika/{{ solr.tika.version }}/tika-server-standard-{{ solr.tika.version }}.jar"
+    dest: "{{ solr.tika.prefix.bin }}/tika-server-{{ solr.tika.version }}.jar"
+    checksum: "sha512:https://archive.apache.org/dist/tika/{{ solr.tika.version }}/tika-server-standard-{{ solr.tika.version }}.jar.sha512"
+    owner: root
+    group: "{{ root_group }}"
+    mode: "0755"
   notify: Restart Tika
 
 - name: Install Tika service
-  template:
+  ansible.builtin.template:
     src: rc.d/tika
     dest: "{{ item }}"
     owner: root
     group: wheel
-    mode: 0755
+    mode: "0755"
   with_items:
     - /etc/rc.d/tika
   notify: Start Tika
 
 - name: Enable Tika service
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ item }}"
     regexp: "^tika_enable="
     line: 'tika_enable="YES"'

--- a/templates/apache/Includes/solr.conf.j2
+++ b/templates/apache/Includes/solr.conf.j2
@@ -1,0 +1,52 @@
+{% set http_listeners = ['*:80'] %}
+{% set https_listeners = ['*:443'] %}
+{% if ansible_local.proserver is defined and ansible_local.proserver.routing.with_gate64 -%}
+{% set _ = http_listeners.append('[::]:87') %}
+{% set _ = https_listeners.append('[::]:57') %}
+{% endif %}
+
+{% for i in http_listeners %}
+<VirtualHost {{ i }}>
+  {% if "57" in i %}
+  RemoteIPProxyProtocol On
+  {% endif %}
+  ServerName {{ solr.domain }}
+  RewriteEngine On
+  RewriteCond %{REQUEST_URI} !^/\.well\-known/acme\-challenge/
+  RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
+</VirtualHost>
+{% endfor %}
+
+{% if dehydrated | cert_exists(solr.domain) %}
+{% for i in https_listeners %}
+<VirtualHost {{ i }}>
+    {% if "87" in i %}
+    RemoteIPProxyProtocol On
+    {% endif %}
+    ServerName {{ solr.domain }}
+    DocumentRoot /var/null
+
+    SSLEngine on
+    SSLProxyEngine on
+    {% if solr.oauth2_proxy is defined and solr.oauth2_proxy -%}
+    ProxyPass /proserver/iap/auth/ http://127.0.0.1:{{ oauth2_proxy.config[typo3.oauth2_proxy].http_address.split(":")[-1] }}/proserver/iap/auth/
+    ProxyPassReverse /proserver/iap/auth/ http://127.0.0.1:{{ oauth2_proxy.config[typo3.oauth2_proxy].http_address.split(":")[-1] }}/proserver/iap/auth/
+
+    ErrorDocument 401 /proserver/iap/sign_in
+
+    RequestHeader set Auth-Cookie %{upstream_set_cookie}e env=upstream_set_cookie
+    Header always set Cookie "%{env:upstream_set_cookie}e" env=upstream_set_cookie
+    {% endif -%}
+
+    ProxyPass / http://127.0.0.1:8983/
+    ProxyPassReverse / http://127.0.0.1:8983/
+    ProxyPreserveHost On
+    ProxyPassInterpolateEnv On
+
+    SSLCertificateFile {{ dehydrated | cert_fullchain(solr.domain) }}
+    SSLCertificateChainFile {{ dehydrated | cert_fullchain(solr.domain) }}
+    SSLCertificateKeyFile {{ dehydrated | cert_privkey(solr.domain) }}
+
+</VirtualHost>
+{% endfor %}
+{% endif %}

--- a/templates/apache/Includes/solr.conf.j2
+++ b/templates/apache/Includes/solr.conf.j2
@@ -29,8 +29,8 @@
     SSLEngine on
     SSLProxyEngine on
     {% if solr.oauth2_proxy is defined and solr.oauth2_proxy -%}
-    ProxyPass /proserver/iap/auth/ http://127.0.0.1:{{ oauth2_proxy.config[typo3.oauth2_proxy].http_address.split(":")[-1] }}/proserver/iap/auth/
-    ProxyPassReverse /proserver/iap/auth/ http://127.0.0.1:{{ oauth2_proxy.config[typo3.oauth2_proxy].http_address.split(":")[-1] }}/proserver/iap/auth/
+    ProxyPass /proserver/iap/auth/ http://127.0.0.1:{{ oauth2_proxy.config[solr.oauth2_proxy].http_address.split(":")[-1] }}/proserver/iap/auth/
+    ProxyPassReverse /proserver/iap/auth/ http://127.0.0.1:{{ oauth2_proxy.config[solr.oauth2_proxy].http_address.split(":")[-1] }}/proserver/iap/auth/
 
     ErrorDocument 401 /proserver/iap/sign_in
 


### PR DESCRIPTION
Other changes:
- Checksum is now pulled dynamically from the Apache Archive and does not need to be hardcoded
- Switch between Apache and Nginx by adding your host to the appropriate inventory group. Nginx is the default
- Various syntax and linting fixes