### PR TITLE
Add letsencrypt handling if solr is handled standalone on a proserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ id_ed25519*
 .collections
 roles
 .venv
+meta/.galaxy_install_info

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -11,3 +11,4 @@ solr:
     version: 3.0.0
   oauth2_proxy:
   overwrite_home: no
+

--- a/tasks/solr.yaml
+++ b/tasks/solr.yaml
@@ -38,7 +38,7 @@
 
 - name: Check the current Solr version
   changed_when: no
-  when: solr_bin_exists
+  when: solr_bin_exists.stat.exists
   register: solr_current_version
   ansible.builtin.command:
     cmd: "{{ solr.prefix.bin }}/bin/solr version"

--- a/templates/nginx/http.d/solr.conf.j2
+++ b/templates/nginx/http.d/solr.conf.j2
@@ -1,14 +1,34 @@
+{% if dehydrated | cert_exists(solr.domain) %}
 server {
-    {% if dehydrated|cert_exists(solr.domain) -%}
-    listen 0.0.0.0:443 ssl http2;
-    listen [::]:443 ssl http2;
-    {% if ansible_local.proserver.routing.with_gate64 -%}
-    listen [::1]:57 ssl http2 proxy_protocol;
+  listen 0.0.0.0:80;
+  listen [::]:80;
+  {% if ansible_local.proserver | default(none) and ansible_local.proserver.routing.with_gate64 -%}
+  listen [::1]:87 proxy_protocol;
+  {%- endif %}
+
+  server_name {{ solr.domain }};
+
+  root /var/null;
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+
+  include {{ nginx.prefix.config }}/include/letsencrypt.conf;
+}
+{% endif %}
+server {
+    {% if dehydrated | cert_exists(solr.domain) -%}
+    listen 0.0.0.0:443 ssl;
+    listen [::]:443 ssl;
+    {% if ansible_local.proserver | default(none) and ansible_local.proserver.routing.with_gate64 -%}
+    listen [::1]:57 ssl proxy_protocol;
     {%- endif %}
+    http2 on;
     {% else %}
     listen 0.0.0.0:80;
     listen [::]:80;
-    {% if ansible_local.proserver.routing.with_gate64 -%}
+    {% if ansible_local.proserver | default(none) and ansible_local.proserver.routing.with_gate64 -%}
     listen [::1]:87 proxy_protocol;
     {%- endif %}
     {% endif %}

--- a/templates/supervisord.d/tika.conf
+++ b/templates/supervisord.d/tika.conf
@@ -1,6 +1,6 @@
 [program:tika]
 user=solr
-command=/usr/local/bin/java -Xmx1g -jar /var/opt/tika/tika-server.jar -h localhost -p 9998
+command=/usr/local/bin/java -Xmx1g -jar {{ solr.prefix.tika }}/tika-server.jar -h localhost -p 9998
 startsecs=5
 environment=PATH=/usr/local/bin:/usr/bin
 stdout_logfile={{ solr.prefix.logs }}/tika.log


### PR DESCRIPTION
Also fixed tika supervisord-path
Fixed check if solr-bin is available